### PR TITLE
Ajout de la possibilité de sélectionner le bus i2c utilisé par les capteurs

### DIFF
--- a/BH1750/bh1750.cpp
+++ b/BH1750/bh1750.cpp
@@ -18,9 +18,9 @@ using namespace std;
     @brief  constructor
 */
 
-bh1750::bh1750(int i2cAddress)
+bh1750::bh1750(int i2cAddress, int i2cBus)
 {
-    deviceI2C = new i2c(i2cAddress);
+    deviceI2C = new i2c(i2cAddress, i2cBus);
     resolution = 1.0;
 
 }

--- a/BH1750/bh1750.h
+++ b/BH1750/bh1750.h
@@ -41,7 +41,7 @@ class bh1750
 {
     public:
     // le constructeur
-    bh1750(int i2cAddress=ADRESSE_I2C_DEFAUT);
+    bh1750(int i2cAddress=ADRESSE_I2C_DEFAUT, int i2cBus=I2C_DEFAULT_BUS);
     // le destructeur
     ~bh1750();
     // méthode pour lire la valeur de l'éclairement

--- a/BH1750/i2c.h
+++ b/BH1750/i2c.h
@@ -13,6 +13,8 @@
 #include <iostream>
 
 
+#define I2C_DEFAULT_BUS 1
+
 // I2C definitions
 
 #define I2C_SLAVE	0x0703  /* Use this slave address */
@@ -70,9 +72,9 @@ class i2c
     public:
 
             // le constructeur
-	    i2c(int adresseI2C, int idBusI2C=1);
+	          i2c(int adresseI2C, int idBusI2C=I2C_DEFAULT_BUS);
             //idBusI2C = 0 pour les raspberry version 1
-            //idBusI2C = 1 pour les raspberry version 2 et 3
+            //idBusI2C = 1 pour les raspberry version 2, 3 et 4
 
             unsigned char Read ();
             unsigned char ReadReg8 (int reg);

--- a/BH1750/i2c.h
+++ b/BH1750/i2c.h
@@ -72,7 +72,7 @@ class i2c
     public:
 
             // le constructeur
-	          i2c(int adresseI2C, int idBusI2C=I2C_DEFAULT_BUS);
+            i2c(int adresseI2C, int idBusI2C=I2C_DEFAULT_BUS);
             //idBusI2C = 0 pour les raspberry version 1
             //idBusI2C = 1 pour les raspberry version 2, 3 et 4
 

--- a/BME280/bme280.cpp
+++ b/BME280/bme280.cpp
@@ -20,9 +20,9 @@
 using namespace std;
 
 
-bme280::bme280(int i2cAddress)  	// Le constructeur
+bme280::bme280(int i2cAddress, int i2cBus)  	// Le constructeur
 {
-    deviceI2C = new i2c(i2cAddress);
+    deviceI2C = new i2c(i2cAddress, i2cBus);
     if (!deviceI2C->getError()){
 
   	readCalibrationData();

--- a/BME280/bme280.h
+++ b/BME280/bme280.h
@@ -118,7 +118,7 @@ class bme280
 
 public:
     // le constructeur
-    bme280(int i2cAddress=ADRESSE_I2C_DEFAUT);
+    bme280(int i2cAddress=ADRESSE_I2C_DEFAUT, int i2cBus=I2C_DEFAULT_BUS);
     // le destructeur
     ~bme280();
 

--- a/BME280/i2c.h
+++ b/BME280/i2c.h
@@ -72,7 +72,7 @@ class i2c
     public:
 
         // le constructeur
-	i2c(int adresseI2C, int idBusI2C=I2C_DEFAULT_BUS);
+        i2c(int adresseI2C, int idBusI2C=I2C_DEFAULT_BUS);
         //idBusI2C = 0 pour les raspberry version 1
         //idBusI2C = 1 pour les raspberry version 2, 3 et 4
 

--- a/BME280/i2c.h
+++ b/BME280/i2c.h
@@ -13,6 +13,7 @@
 #include <iostream>
 
 
+#define I2C_DEFAULT_BUS 1
 
 // I2C definitions
 
@@ -71,9 +72,9 @@ class i2c
     public:
 
         // le constructeur
-	i2c(int adresseI2C, int idBusI2C=1);
+	i2c(int adresseI2C, int idBusI2C=I2C_DEFAULT_BUS);
         //idBusI2C = 0 pour les raspberry version 1
-        //idBusI2C = 1 pour les raspberry version 2 et 3
+        //idBusI2C = 1 pour les raspberry version 2, 3 et 4
 
 	bool getError();
 

--- a/DS1631/Ds1631.cpp
+++ b/DS1631/Ds1631.cpp
@@ -4,10 +4,10 @@
 using namespace std;
 
 
-Ds1631::Ds1631(int i2cAddress)  	// Le constructeur
+Ds1631::Ds1631(int i2cAddress, int i2cBus)  	// Le constructeur
 {
 
-    deviceI2C = new i2c(i2cAddress);
+    deviceI2C = new i2c(i2cAddress, i2cBus);
 
     m_config = 8+4+1; 			// conversion sur 12 bits / one shot
     deviceI2C->WriteReg8(0xAC, m_config);

--- a/DS1631/Ds1631.h
+++ b/DS1631/Ds1631.h
@@ -10,7 +10,7 @@ class Ds1631
 {
     public:
 
-    Ds1631(int i2cAddress=0x48);
+    Ds1631(int i2cAddress=0x48, int i2cBus=I2C_DEFAULT_BUS);
     float getTemperature();			   // Donne la temperature en °C
     void  afficher(std::ostream &flux);            // Methode pour afficher la temperature en °C
     float getThigh();				   // donne le seuil haut du thermostat

--- a/DS1631/i2c.h
+++ b/DS1631/i2c.h
@@ -13,6 +13,8 @@
 #include <stdlib.h>
 
 
+#define I2C_DEFAULT_BUS 1
+
 // I2C definitions
 
 #define I2C_SLAVE	0x0703
@@ -66,7 +68,9 @@ class i2c
 
 
             // le constructeur
-            i2c(int adresseI2C, int idBusI2C=1);  // par défaut raspberry pi 2 et 3
+            i2c(int adresseI2C, int idBusI2C=I2C_DEFAULT_BUS);
+            //idBusI2C = 0 pour les raspberry version 1
+            //idBusI2C = 1 pour les raspberry version 2, 3 et 4
 
             unsigned char Read ();
             unsigned char ReadReg8 (int reg);

--- a/INA219/i2c.h
+++ b/INA219/i2c.h
@@ -13,6 +13,7 @@
 #include <iostream>
 
 
+#define I2C_DEFAULT_BUS 1
 
 // I2C definitions
 
@@ -71,9 +72,9 @@ class i2c
     public:
 
         // le constructeur
-	i2c(int adresseI2C, int idBusI2C=1);
+        i2c(int adresseI2C, int idBusI2C=I2C_DEFAULT_BUS);
         //idBusI2C = 0 pour les raspberry version 1
-        //idBusI2C = 1 pour les raspberry version 2 et 3
+        //idBusI2C = 1 pour les raspberry version 2, 3 et 4
 
 	bool getError();
 

--- a/INA219/ina219.cpp
+++ b/INA219/ina219.cpp
@@ -31,9 +31,9 @@ using namespace std;
     @note   These calculations assume a 0.1 ohm resistor is present
 */
 
-ina219::ina219(int i2cAddress, float  _quantum)
+ina219::ina219(int i2cAddress, float  _quantum, int i2cBus)
 {
-    deviceI2C = new i2c(i2cAddress);
+    deviceI2C = new i2c(i2cAddress, i2cBus);
     if (!deviceI2C->getError()){
     	deviceI2C->WriteReg16(REG_CONFIG, 0x0080);   // reset
 

--- a/INA219/ina219.h
+++ b/INA219/ina219.h
@@ -80,7 +80,7 @@ class ina219
 
     public:
     // le constructeur
-    ina219(int i2cAddress=ADRESSE_I2C_DEFAUT, float _quantum=3.991);
+    ina219(int i2cAddress=ADRESSE_I2C_DEFAUT, float _quantum=3.991, int i2cBus=I2C_DEFAULT_BUS);
     // le destructeur
     ~ina219();
     bool obtenirErreur();

--- a/i2c/i2c.h
+++ b/i2c/i2c.h
@@ -13,6 +13,7 @@
 #include <iostream>
 
 
+#define I2C_DEFAULT_BUS 1
 
 // I2C definitions
 
@@ -71,9 +72,9 @@ class i2c
     public:
 
         // le constructeur
-	i2c(int adresseI2C, int idBusI2C=1);
+        i2c(int adresseI2C, int idBusI2C=I2C_DEFAULT_BUS);
         //idBusI2C = 0 pour les raspberry version 1
-        //idBusI2C = 1 pour les raspberry version 2 et 3
+        //idBusI2C = 1 pour les raspberry version 2, 3 et 4
 
 	bool getError();
 


### PR DESCRIPTION
Bonjour,

Je possède un capteur BME280 que je pilote depuis mon raspberry pi 4 grâce à votre bibliothèque. Et contrairement aux modèles précédents, le RPi4 possèdent plusieurs bus i2c (Je me sers moi même d'un bus autre que le bus 1). Du coup, si cela vous intéresse, j'ai mis à jour la bibliothèque de mon côté afin de permettre le choix, lors de l'initialisation de la communication avec un capteur, du bus i2c à utiliser.